### PR TITLE
Fix code scanning alert no. 2: Multiplication result converted to larger type

### DIFF
--- a/src/dsdiff_file_reader.cpp
+++ b/src/dsdiff_file_reader.cpp
@@ -163,7 +163,7 @@ bool DsdiffFileReader::readNextBlock() {
 				errorMsg = "dsfFileReader::readNextBlock:file read error";
 				ok = false;
 			}
-		} else if (file.read_uint8(sampleBuffer,chanNum*sampleBufferLenPerChan)) {
+		} else 		if (file.read_uint8(sampleBuffer, static_cast<dsf2flac_uint64>(chanNum) * sampleBufferLenPerChan)) {
 			errorMsg = "dsfFileReader::readNextBlock:file read error";
 			ok = false;
 		}


### PR DESCRIPTION
Fixes [https://github.com/kagemomiji/dsf2flac/security/code-scanning/2](https://github.com/kagemomiji/dsf2flac/security/code-scanning/2)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `dsf2flac_uint64` before performing the multiplication. This way, the multiplication will be done using 64-bit arithmetic, and the result will be correctly stored in a `stream_size` variable.

Specifically, we will cast `chanNum` to `dsf2flac_uint64` before multiplying it by `sampleBufferLenPerChan` on line 166. This change will ensure that the multiplication does not overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
