### PR TITLE
Update ax boost timer m4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 AC_PREREQ([2.69])
 AC_INIT([dsf2flac], [1.0])
 AC_CONFIG_SRCDIR([src/main.cpp])
-AM_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([foreign -Wall])
 AC_LANG(C++)
 AM_PROG_AR

--- a/m4/ax_boost_timer.m4
+++ b/m4/ax_boost_timer.m4
@@ -8,7 +8,7 @@
 #
 # DESCRIPTION
 #
-#   Test for Timer library from the Boost C++ libraries. The macro requires
+#   Test for System library from the Boost C++ libraries. The macro requires
 #   a preceding call to AX_BOOST_BASE. Further documentation is available at
 #   <http://randspringer.de/boost/index.html>.
 #
@@ -23,13 +23,14 @@
 # LICENSE
 #
 #   Copyright (c) 2012 Xiyue Deng <manphiz@gmail.com>
+#   Copyright (c) 2012 Murray Cumming <murrayc@openismus.com>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 1
+#serial 2 (based on serial 1 of ax_boost_locale.m4 with some simple find/replace by Murray Cumming)
 
 AC_DEFUN([AX_BOOST_TIMER],
 [
@@ -67,8 +68,8 @@ AC_DEFUN([AX_BOOST_TIMER],
         [AC_LANG_PUSH([C++])
 			 CXXFLAGS_SAVE=$CXXFLAGS
 
-			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/timer.hpp>]],
-                                   [[boost::timer timer;]])],
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/timer/timer.hpp>]],
+                                   [[boost::timer::cpu_timer().stop();]])],
                    ax_cv_boost_timer=yes, ax_cv_boost_timer=no)
 			 CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])


### PR DESCRIPTION
This pull request makes updates to the build configuration and Boost library detection macros to improve compatibility and accuracy. The most important changes are grouped below:

**Build configuration updates:**

* Switched from `AM_CONFIG_HEADER` to `AC_CONFIG_HEADERS` in `configure.ac` for better autoconf compatibility.

**Boost library detection improvements:**

* Updated the description in `ax_boost_timer.m4` to refer to the Boost System library instead of Timer, clarifying the macro's purpose.
* Added copyright attribution for Murray Cumming and updated the serial number/comment to indicate the macro is now based on `ax_boost_locale.m4`.
* Changed the header inclusion and test code in the Boost Timer macro to use `<boost/timer/timer.hpp>` and `boost::timer::cpu_timer().stop();`, reflecting the modern Boost Timer API.