### PR TITLE
fix: Update CodeQL initialization to use only C++ language

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -27,7 +27,8 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
-        languages: cpp, python
+        languages: cpp
+        build-mode: manual
 
     - name: Build project
       run: |


### PR DESCRIPTION
This pull request makes a small change to the CodeQL analysis workflow configuration. The change restricts CodeQL analysis to only C++ and sets the build mode to manual.