### PR TITLE
Potential fix for code scanning alert no. 2: Multiplication result converted to larger type

### DIFF
--- a/src/dsdiff_file_reader.cpp
+++ b/src/dsdiff_file_reader.cpp
@@ -166,7 +166,7 @@ bool DsdiffFileReader::readNextBlock() {
 				errorMsg = "dsfFileReader::readNextBlock:file read error";
 				ok = false;
 			}
-		} else if (file.read_uint8(sampleBuffer,chanNum*sampleBufferLenPerChan)) {
+		} else if (file.read_uint8(sampleBuffer, static_cast<stream_size>(chanNum) * sampleBufferLenPerChan)) {
 			errorMsg = "dsfFileReader::readNextBlock:file read error";
 			ok = false;
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/kagemomiji/dsf2flac/security/code-scanning/2](https://github.com/kagemomiji/dsf2flac/security/code-scanning/2)

To ensure that the multiplication is performed in a wide enough type to prevent overflow, we should explicitly cast at least one of the operands to the larger result type before multiplication. In this case, cast either `chanNum` or `sampleBufferLenPerChan` to `stream_size` (or another 64-bit integer type). This guarantees that the resulting value will not overflow as long as it fits in `stream_size`. Only this expression (line 169) needs to change; no other logic or variable types are affected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
