### PR TITLE
Potential fix for code scanning alert no. 1: Multiplication result converted to larger type

### DIFF
--- a/src/libdstdec/dst_init.c
+++ b/src/libdstdec/dst_init.c
@@ -87,7 +87,7 @@ static void *MemoryAllocate(int NrOfElements, int SizeOfElement)
     fprintf(stderr,"ERROR: not enough memory available!\n\n");
   }
   #else
-  if ((Array = _mm_malloc(NrOfElements * SizeOfElement, 16)) == NULL) 
+  if ((Array = _mm_malloc((size_t)NrOfElements * SizeOfElement, 16)) == NULL) 
   {
     fprintf(stderr,"ERROR: not enough memory available!\n\n");
   }


### PR DESCRIPTION
Potential fix for [https://github.com/kagemomiji/dsf2flac/security/code-scanning/1](https://github.com/kagemomiji/dsf2flac/security/code-scanning/1)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. The `size_t` type is typically used for sizes and is guaranteed to be large enough to hold the result of the multiplication.

- Cast `NrOfElements` to `size_t` before multiplying it with `SizeOfElement`.
- This change should be made in the `MemoryAllocate` function on line 90.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
