### PR TITLE
Fix workflow: dsf2flac binary upload step is included

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,7 +15,6 @@ jobs:
       # clone repository
       - name: Checkout repository
         uses: actions/checkout@v4
-
       # install dependencies
       - name: Install dependencies
         run: |
@@ -53,3 +52,9 @@ jobs:
         run: |
           chmod +x ./test/test.sh
           ./test/test.sh
+
+      - name: Upload dsf2flac binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: dsf2flac
+          path: ./src/dsf2flac

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -54,7 +54,7 @@ jobs:
           ./test/test.sh
 
       - name: Upload dsf2flac binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dsf2flac
           path: ./src/dsf2flac


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/build-and-test.yaml` to improve artifact management. The most significant change is the addition of a step to upload the `dsf2flac` binary after running tests.

**CI workflow improvements:**

* Added a new step to upload the `dsf2flac` binary as a build artifact using `actions/upload-artifact@v3`, making the built binary available for download after CI runs.
* Minor formatting change by removing an unnecessary blank line after the repository checkout step for cleaner YAML structure.…